### PR TITLE
Added anonymous attribute to post and changed how authors/users of an anonymous post is displayed

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -12,6 +12,8 @@ PostObject:
     uid:
       type: number
       description: A user identifier
+    anonymous:
+      type: boolean
     timestamp:
       type: number
     deleted:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -59,6 +59,8 @@ get:
                         tid:
                           type: number
                           description: A topic identifier
+                        anonymous:
+                          type: number
                         content:
                           type: string
                         timestamp:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -32,6 +32,8 @@ get:
                   tid:
                     type: number
                     description: A topic identifier
+                  anonymous:
+                    type: number
                   content:
                     type: string
                   timestamp:

--- a/public/openapi/write/posts/pid/replies.yaml
+++ b/public/openapi/write/posts/pid/replies.yaml
@@ -37,6 +37,8 @@ get:
                         tid:
                           type: number
                           description: A topic identifier
+                        anonymous:
+                          type: number
                         content:
                           type: string
                         timestamp:

--- a/src/categories/recentreplies.js
+++ b/src/categories/recentreplies.js
@@ -172,7 +172,7 @@ module.exports = function (Categories) {
 		]);
 
 		await batch.processArray(pids, async (pids) => {
-			const postData = await posts.getPostsFields(pids, ['pid', 'deleted', 'uid', 'timestamp', 'upvotes', 'downvotes']);
+			const postData = await posts.getPostsFields(pids, ['pid', 'deleted', 'uid', 'timestamp', 'upvotes', 'downvotes', 'anonymous']);
 
 			const bulkRemove = [];
 			const bulkAdd = [];

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -295,10 +295,12 @@ async function addTags(topicData, req, res, currentPage) {
 	}
 
 	if (postAtIndex) {
-		res.locals.linkTags.push({
-			rel: 'author',
-			href: `${url}/user/${postAtIndex.user.userslug}`,
-		});
+		if (postAtIndex.anonymous === undefined || !postAtIndex.anonymous) {
+			res.locals.linkTags.push({
+				rel: 'author',
+				href: `${url}/user/${postAtIndex.user.userslug}`,
+			});
+		}
 	}
 }
 

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -19,7 +19,7 @@ module.exports = function (Posts) {
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
-		const anonymous = true;
+		const anonymous = data.anonymous || false;
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -19,6 +19,7 @@ module.exports = function (Posts) {
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
+		const anonymous = true;
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -33,6 +34,7 @@ module.exports = function (Posts) {
 			pid: pid,
 			uid: uid,
 			tid: tid,
+			anonymous: anonymous,
 			content: content,
 			timestamp: timestamp,
 		};

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -67,5 +67,8 @@ function modifyPost(post, fields) {
 		if (post.hasOwnProperty('edited')) {
 			post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
 		}
+		if (post.hasOwnProperty('anonymous')) {
+			post.anonymous = post.anonymous === 'true';
+		}
 	}
 }

--- a/src/posts/delete.js
+++ b/src/posts/delete.js
@@ -26,7 +26,7 @@ module.exports = function (Posts) {
 			deleted: isDeleting ? 1 : 0,
 			deleterUid: isDeleting ? uid : 0,
 		});
-		const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'timestamp']);
+		const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'anonymous', 'content', 'timestamp']);
 		const topicData = await topics.getTopicFields(postData.tid, ['tid', 'cid', 'pinned']);
 		postData.cid = topicData.cid;
 		await Promise.all([

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
 		options.parse = options.hasOwnProperty('parse') ? options.parse : true;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);
@@ -52,6 +52,7 @@ module.exports = function (Posts) {
 			post.isMainPost = post.topic && post.pid === post.topic.mainPid;
 			post.deleted = post.deleted === 1;
 			post.timestampISO = utils.toISOString(post.timestamp);
+			post.anonymous = post.anonymous === undefined ? false : post.anonymous;
 		});
 
 		posts = posts.filter(post => tidToTopic[post.tid]);

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -52,7 +52,7 @@ module.exports = function (Posts) {
 			post.isMainPost = post.topic && post.pid === post.topic.mainPid;
 			post.deleted = post.deleted === 1;
 			post.timestampISO = utils.toISOString(post.timestamp);
-			post.anonymous = post.anonymous === undefined ? false : post.anonymous;
+			post.anonymous = post.anonymous === undefined ? false : (post.anonymous === 1);
 		});
 
 		posts = posts.filter(post => tidToTopic[post.tid]);

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -140,7 +140,7 @@ module.exports = function (Posts) {
 			throw new Error('[[error:no-user]]');
 		}
 		let postData = await Posts.getPostsFields(pids, [
-			'pid', 'tid', 'uid', 'content', 'deleted', 'timestamp', 'upvotes', 'downvotes',
+			'pid', 'tid', 'uid', 'content', 'anonymous', 'deleted', 'timestamp', 'upvotes', 'downvotes',
 		]);
 		postData = postData.filter(p => p.pid && p.uid !== parseInt(toUid, 10));
 		pids = postData.map(p => p.pid);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -120,8 +120,8 @@ module.exports = function (Topics) {
 		const tid = await Topics.create(data);
 
 		let postData = data;
-		if (!postData.anonymous) {
-			postData.anonymous = true;
+		if (postData.anonymous === undefined) {
+			postData.anonymous = false;
 		}
 		postData.tid = tid;
 		postData.ip = data.req ? data.req.ip : null;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -120,6 +120,9 @@ module.exports = function (Topics) {
 		const tid = await Topics.create(data);
 
 		let postData = data;
+		if (!postData.anonymous) {
+			postData.anonymous = true;
+		}
 		postData.tid = tid;
 		postData.ip = data.req ? data.req.ip : null;
 		postData.isMain = true;

--- a/src/topics/fork.js
+++ b/src/topics/fork.js
@@ -92,7 +92,7 @@ module.exports = function (Topics) {
 		if (!forceScheduled && topicData.scheduled) {
 			throw new Error('[[error:cant-move-posts-to-scheduled]]');
 		}
-		const postData = await posts.getPostFields(pid, ['tid', 'uid', 'timestamp', 'upvotes', 'downvotes']);
+		const postData = await posts.getPostFields(pid, ['tid', 'uid', 'timestamp', 'upvotes', 'downvotes', 'anonymous']);
 		if (!postData || !postData.tid) {
 			throw new Error('[[error:no-post]]');
 		}

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -112,22 +112,19 @@ module.exports = function (Topics) {
 			var uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
 			var userData = await method(uids);
 
-			if (field === 'uid') {
-				postData.forEach(post => {
-					if (post && post.anonymous !== undefined && post.anonymous) {
-						const user = userData.find(user => user[field] === post[field]);
-						if (user) {
-							user.username = 'Anonymous';
-						}
-						// Remove the anonymous user from userData and uids
-						const index = uids.indexOf(user[field]);
-						if (index !== -1) {
-							uids.splice(index, 1);
-							userData = userData.filter(u => u[field] !== user[field]);
-						}
-					}
-				});
-			}
+			// if (field === 'uid') {
+			// 	postData.forEach(post => {
+			// 		if (post && post.anonymous !== undefined && post.anonymous) {
+			// 			const user = userData.find(user => user[field] === post[field]);
+			// 			// Remove the anonymous user from userData and uids
+			// 			const index = uids.indexOf(user[field]);
+			// 			if (index !== -1) {
+			// 				uids.splice(index, 1);
+			// 				userData = userData.filter(u => u[field] !== user[field]);
+			// 			}
+			// 		}
+			// 	});
+			// }
 			return _.zipObject(uids, userData);
 		}
 		const [
@@ -160,6 +157,12 @@ module.exports = function (Topics) {
 				if (meta.config.allowGuestHandles && postObj.uid === 0 && postObj.handle) {
 					postObj.user.username = validator.escape(String(postObj.handle));
 					postObj.user.displayname = postObj.user.username;
+				}
+
+				if (postObj.anonymous && postObj.user) {					
+					postObj.user.username = 'Anonymous';
+					postObj.user.displayname = 'Anonymous';
+					postObj.user.userslug = undefined;
 				}
 			}
 		});

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -112,20 +112,22 @@ module.exports = function (Topics) {
 			var uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
 			var userData = await method(uids);
 
-			postData.forEach(post => {
-				if (post && post.anonymous) {
-					const user = userData.find(user => user[field] === post[field]);
-					if (user) {
-						user.username = 'Anonymous';
+			if (field === 'uid') {
+				postData.forEach(post => {
+					if (post && post.anonymous !== undefined && post.anonymous) {
+						const user = userData.find(user => user[field] === post[field]);
+						if (user) {
+							user.username = 'Anonymous';
+						}
+						// Remove the anonymous user from userData and uids
+						const index = uids.indexOf(user[field]);
+						if (index !== -1) {
+							uids.splice(index, 1);
+							userData = userData.filter(u => u[field] !== user[field]);
+						}
 					}
-					// Remove the anonymous user from userData and uids
-					const index = uids.indexOf(user[field]);
-					if (index !== -1) {
-						uids.splice(index, 1);
-						userData = userData.filter(u => u[field] !== user[field]);
-					}
-				}
-			});
+				});
+			}
 			return _.zipObject(uids, userData);
 		}
 		const [

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -11,7 +11,6 @@ const posts = require('../posts');
 const meta = require('../meta');
 const plugins = require('../plugins');
 const utils = require('../utils');
-
 const backlinkRegex = new RegExp(`(?:${nconf.get('url').replace('/', '\\/')}|\b|\\s)\\/topic\\/(\\d+)(?:\\/\\w+)?`, 'g');
 
 module.exports = function (Topics) {
@@ -110,8 +109,8 @@ module.exports = function (Topics) {
 		const pids = postData.map(post => post && post.pid);
 
 		async function getPostUserData(field, method) {
-			const uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
-			const userData = await method(uids);
+			var uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
+			var userData = await method(uids);
 			return _.zipObject(uids, userData);
 		}
 		const [

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -11,6 +11,7 @@ const posts = require('../posts');
 const meta = require('../meta');
 const plugins = require('../plugins');
 const utils = require('../utils');
+
 const backlinkRegex = new RegExp(`(?:${nconf.get('url').replace('/', '\\/')}|\b|\\s)\\/topic\\/(\\d+)(?:\\/\\w+)?`, 'g');
 
 module.exports = function (Topics) {
@@ -109,22 +110,8 @@ module.exports = function (Topics) {
 		const pids = postData.map(post => post && post.pid);
 
 		async function getPostUserData(field, method) {
-			var uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
-			var userData = await method(uids);
-
-			// if (field === 'uid') {
-			// 	postData.forEach(post => {
-			// 		if (post && post.anonymous !== undefined && post.anonymous) {
-			// 			const user = userData.find(user => user[field] === post[field]);
-			// 			// Remove the anonymous user from userData and uids
-			// 			const index = uids.indexOf(user[field]);
-			// 			if (index !== -1) {
-			// 				uids.splice(index, 1);
-			// 				userData = userData.filter(u => u[field] !== user[field]);
-			// 			}
-			// 		}
-			// 	});
-			// }
+			const uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
+			const userData = await method(uids);
 			return _.zipObject(uids, userData);
 		}
 		const [
@@ -159,10 +146,10 @@ module.exports = function (Topics) {
 					postObj.user.displayname = postObj.user.username;
 				}
 
-				if (postObj.anonymous && postObj.user) {					
+				if (postObj.anonymous && postObj.user) {
 					postObj.user.username = 'Anonymous';
 					postObj.user.displayname = 'Anonymous';
-					postObj.user.userslug = undefined;
+					postObj.user.userslug = '';
 				}
 			}
 		});

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -111,6 +111,15 @@ module.exports = function (Topics) {
 		async function getPostUserData(field, method) {
 			var uids = _.uniq(postData.filter(p => p && parseInt(p[field], 10) >= 0).map(p => p[field]));
 			var userData = await method(uids);
+
+			postData.forEach(post => {
+				if (post && post.anonymous) {
+					const user = userData.find(user => user[field] === post[field]);
+					if (user) {
+						user.username = 'Anonymous';
+					}
+				}
+			});
 			return _.zipObject(uids, userData);
 		}
 		const [

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -118,6 +118,12 @@ module.exports = function (Topics) {
 					if (user) {
 						user.username = 'Anonymous';
 					}
+					// Remove the anonymous user from userData and uids
+					const index = uids.indexOf(user[field]);
+					if (index !== -1) {
+						uids.splice(index, 1);
+						userData = userData.filter(u => u[field] !== user[field]);
+					}
 				}
 			});
 			return _.zipObject(uids, userData);

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -334,7 +334,7 @@ module.exports = function (Topics) {
 
 		const uniquePids = _.uniq(_.flatten(arrayOfReplyPids));
 
-		let replyData = await posts.getPostsFields(uniquePids, ['pid', 'uid', 'timestamp']);
+		let replyData = await posts.getPostsFields(uniquePids, ['pid', 'uid', 'timestamp', 'anonymous']);
 		const result = await plugins.hooks.fire('filter:topics.getPostReplies', {
 			uid: callerUid,
 			replies: replyData,

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -78,7 +78,7 @@ User.getUsersWithFields = async function (uids, fields, uid) {
 	const userData = await User.getUsersFields(uids, results.fields);
 	results = await plugins.hooks.fire('filter:userlist.get', { users: userData, uid: uid });
 	return results.users;
-}; 
+};
 
 User.getUsers = async function (uids, uid) {
 	const userData = await User.getUsersWithFields(uids, [

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -78,7 +78,7 @@ User.getUsersWithFields = async function (uids, fields, uid) {
 	const userData = await User.getUsersFields(uids, results.fields);
 	results = await plugins.hooks.fire('filter:userlist.get', { users: userData, uid: uid });
 	return results.users;
-};
+}; 
 
 User.getUsers = async function (uids, uid) {
 	const userData = await User.getUsersWithFields(uids, [


### PR DESCRIPTION
Resolves #4 

Added an anonymous attribute (boolean) to a post in the redis database. This was done by adding the attribute when creating a post in `src/posts/create.js` and adding to the schema in `public/openapi/components/schemas/PostObject.yaml`

Since there is no code allowing user to make a post anonymous when creating a post because we could not get the UI changes implemented, the anonymous attribute is hard-coded as true for all posts. This will need to be changed once code that implements marking a post as anonymous if indicated by the user is complete which will require a new issue.

Modified how authors of an anonymous posts are displayed. The user/author information for a post is modified if anonymous is true such that their display name and username are changed to anonymous and the userslug is no longer the url to their profile. The user's profile picture still shows even if anonymous which will need to be changed in a new issue.

**UI Image**
<img width="1540" alt="Screenshot 2024-09-24 at 3 20 23 PM" src="https://github.com/user-attachments/assets/5a2816e7-ed63-4711-a287-e81d3c589e0a">


**Open Bugs**
The tests generated from npm run test fail due to not finding the anonymous attribute in the database schema even though I modified the schema file PostObject.yaml and reran `./nodebb setup` after dropping the database. It may be that the schema is stored somewhere else as well that needs to be modified, but I was unable to find where this was. I will go to office hours in Sprint 2 to resolve this issue.

`1) response body should match schema definition:
     AssertionError [ERR_ASSERTION]: "anonymous" was found in response, but is not defined in schema (path: GET /api/topic/{topic_id}/{slug}, context: root.posts)`