### PR TITLE
Integrated frontend repo to Azure deployment

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -109,7 +109,7 @@
         "nodebb-theme-peace": "2.2.6",
         "nodebb-theme-persona": "13.3.25",
         "nodebb-widget-essentials": "7.0.18",
-        "nodebb-frontend-repo": "git+https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars.git"
+        "nodebb-frontend-repo": "git+https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars.git",
         "nodemailer": "6.9.13",
         "nprogress": "0.2.0",
         "passport": "0.7.0",

--- a/install/package.json
+++ b/install/package.json
@@ -109,6 +109,7 @@
         "nodebb-theme-peace": "2.2.6",
         "nodebb-theme-persona": "13.3.25",
         "nodebb-widget-essentials": "7.0.18",
+        "nodebb-frontend-repo": "git+https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars.git"
         "nodemailer": "6.9.13",
         "nprogress": "0.2.0",
         "passport": "0.7.0",


### PR DESCRIPTION
In order for our frontend changes located at [this repo](https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars) to be shown in our Azure deployment, I added the github link to our team's frontend repo to the dependencies in package.json.