### PR TITLE
Revert "Integrated frontend repo to Azure deployment"

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -109,7 +109,6 @@
         "nodebb-theme-peace": "2.2.6",
         "nodebb-theme-persona": "13.3.25",
         "nodebb-widget-essentials": "7.0.18",
-        "nodebb-frontend-repo": "git+https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars.git",
         "nodemailer": "6.9.13",
         "nprogress": "0.2.0",
         "passport": "0.7.0",


### PR DESCRIPTION
Reverts CMU-313/nodebb-f24-team-software-stars#45

This is not the correct way to add a dependency to the Azure build. The repo was being deployed properly but it did not reflect the new frontend changes.