### PR TITLE
Modified azure workflow to install frontend repo

### DIFF
--- a/.github/workflows/azure-deploy-f24.yml
+++ b/.github/workflows/azure-deploy-f24.yml
@@ -43,6 +43,14 @@ jobs:
             "redis:host": "${{ secrets.REDIS_HOST }}",
             "redis:port": "6379",
             "redis:password": "${{ secrets.REDIS_PASSWORD }}" }'
+      
+      - name: Clone frontend repo
+        run: |
+          git clone https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars.git
+      
+      - name: Install frontend repo as a dependency
+        run: |
+          npm install ../nodebb-frontend-f24-team-software-stars
           
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp


### PR DESCRIPTION
Added steps to Azure workflow that will git clone the frontend repo and then install it with npm install. This will happen after the ./nodebb setup command is run.