### PR TITLE
Moved npm install before nodebb setup command

### DIFF
--- a/.github/workflows/azure-deploy-f24.yml
+++ b/.github/workflows/azure-deploy-f24.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           node-version: '20.17.0'
 
+      - name: Clone frontend repo as a subdirectory
+        run: |
+          git clone https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars.git
+      
+      - name: Install frontend repo as a dependency
+        run: |
+          npm install ./nodebb-frontend-f24-team-software-stars
+
       - name: Set up NodeBB
         run: |
           ./nodebb setup '{"url":"https://nodebb-software-stars.azurewebsites.net:443",
@@ -43,14 +51,6 @@ jobs:
             "redis:host": "${{ secrets.REDIS_HOST }}",
             "redis:port": "6379",
             "redis:password": "${{ secrets.REDIS_PASSWORD }}" }'
-      
-      - name: Clone frontend repo
-        run: |
-          git clone https://github.com/CMU-313/nodebb-frontend-f24-team-software-stars.git
-      
-      - name: Install frontend repo as a dependency
-        run: |
-          npm install ./nodebb-frontend-f24-team-software-stars
           
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp


### PR DESCRIPTION
Switched the order of the commands in the azure-deploy-f24.yml file as I was getting an error during deployment. Now, ./nodebb setup runs after cloning and installing the frontend repo.